### PR TITLE
Enables reacting to user pin attempts in AppLockActivity.

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -37,6 +37,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     protected TypefaceTextView mForgotTextView;
 
     protected int mType = AppLock.UNLOCK_PIN;
+    protected int mAttempts = 1;
     protected int mLogoId;
     protected String mPinCode;
     protected String mOldPinCode;
@@ -185,6 +186,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                 if (mLockManager.getAppLock().checkPasscode(mPinCode)) {
                     setResult(RESULT_OK);
                     mLockManager.getAppLock().setPasscode(null);
+                    onPinCodeSuccess();
                     finish();
                 } else {
                     onPinCodeError();
@@ -199,6 +201,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                     if (mPinCode.equals(mOldPinCode)) {
                         setResult(RESULT_OK);
                         mLockManager.getAppLock().setPasscode(mPinCode);
+                        onPinCodeSuccess();
                         finish();
                     } else {
                         mOldPinCode = "";
@@ -213,6 +216,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
                     mStepTextView.setText(getString(R.string.pin_code_step_create));
                     mType = AppLock.ENABLE_PINLOCK;
                     setPinCode("");
+                    onPinCodeSuccess();
                     initText();
                 } else {
                     onPinCodeError();
@@ -221,6 +225,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             case AppLock.UNLOCK_PIN:
                 if (mLockManager.getAppLock().checkPasscode(mPinCode)) {
                     setResult(RESULT_OK);
+                    onPinCodeSuccess();
                     finish();
                 } else {
                     onPinCodeError();
@@ -248,6 +253,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      * Run a shake animation when the password is not valid.
      */
     protected void onPinCodeError() {
+        onPinFailure(mAttempts++);
         Thread thread = new Thread() {
             public void run() {
                 mPinCode = "";
@@ -258,6 +264,11 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             }
         };
         runOnUiThread(thread);
+    }
+
+    protected void onPinCodeSuccess() {
+        onPinSuccess(mAttempts);
+        mAttempts = 1;
     }
 
     /**
@@ -285,4 +296,16 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     public void onClick(View view) {
         showForgotDialog();
     }
+
+    /**
+     * When the user has failed a pin challenge
+     * @param attempts the number of attempts the user has used
+     */
+    public abstract void onPinFailure(int attempts);
+
+    /**
+     * When the user has succeeded at a pin challenge
+     * @param attempts the number of attempts the user had used
+     */
+    public abstract void onPinSuccess(int attempts);
 }


### PR DESCRIPTION
This is a squashed version of "Feature/attempt listening #12". 

By overriding

public void onPinSuccess(int attempts)

and/or

public void onPinFailure(int attempts)

you can react to a user passing or failing a pin code challenge. 
Example: after 5 incorrect pin attempts log a user out and close the app.