### PR TITLE
Allows a client app to supply different strings

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -88,6 +88,10 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         }
 
         findViewById(R.id.pin_code_logo_imageview).setBackgroundResource(mLockManager.getAppLock().getLogoId());
+        findViewById(R.id.pin_code_logo_imageview)
+                .setBackgroundResource(mLockManager.getAppLock().getLogoId());
+        TypefaceTextView forgot = (TypefaceTextView) findViewById(R.id.pin_code_forgot_textview);
+        forgot.setText(getForgotText());
 
         initText();
     }
@@ -96,20 +100,35 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      * Init the {@link #mStepTextView} based on {@link #mType}
      */
     private void initText() {
-        switch (mType) {
+        mStepTextView.setText(getMessage(mType));
+    }
+
+    /**
+     * Gets the {@link String} to be used in the {@link #mStepTextView} based on {@link #mType}
+     * @param reason The {@link #mType} to return a {@link String} for
+     * @return The {@link String} for the {@link AppLockActivity}
+     */
+    public String getMessage(int reason) {
+        String msg = null;
+        switch (reason) {
             case AppLock.DISABLE_PINLOCK:
-                mStepTextView.setText(getString(R.string.pin_code_step_disable));
+                msg = getString(R.string.pin_code_step_disable);
                 break;
             case AppLock.ENABLE_PINLOCK:
-                mStepTextView.setText(getString(R.string.pin_code_step_create));
+                msg = getString(R.string.pin_code_step_create);
                 break;
             case AppLock.CHANGE_PIN:
-                mStepTextView.setText(getString(R.string.pin_code_step_change));
+                msg = getString(R.string.pin_code_step_change);
                 break;
             case AppLock.UNLOCK_PIN:
-                mStepTextView.setText(getString(R.string.pin_code_step_unlock));
+                msg = getString(R.string.pin_code_step_unlock);
                 break;
         }
+        return msg;
+    }
+
+    public String getForgotText() {
+        return getString(R.string.pin_code_forgot_text);
     }
 
     /**

--- a/lib/src/main/res/layout/activity_pin_code.xml
+++ b/lib/src/main/res/layout/activity_pin_code.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
     android:background="@android:color/white"
@@ -48,7 +49,7 @@
             android:layout_centerInParent="true"
             android:textColor="@color/dark_grey_color"
             android:textSize="@dimen/pin_code_forgot_text_size"
-            android:text="@string/pin_code_forgot_text"
+            tools:text="@string/pin_code_forgot_text"
             android:singleLine="true"
             app:typeface="Roboto-Regular.ttf"
             android:layout_below="@+id/pin_code_round_view" />


### PR DESCRIPTION
Allows a client app to override getMessage(int reason) and/or getForgotText() to supply different strings (possibly for localization).

Squashed PR of "Feature/supply strings #13"