### PR TITLE
Allows backing out of Pin Change and Pin Disable.

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -236,6 +236,9 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onBackPressed() {
+        if (mType == AppLock.CHANGE_PIN || mType == AppLock.DISABLE_PINLOCK) {
+            super.onBackPressed();
+        }
     }
 
     /**


### PR DESCRIPTION
Allows for use of the back button only when a user is not entering a pin in for a pin challenge. This means that if the user is changing, removing, or setting a pin they can back out and cancel the process.

Squashed PR of "Feature/cancel #14"