### PR TITLE
Makes forgot optional.

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -84,6 +84,16 @@ public abstract class AppLock {
     public abstract void setLogoId(int logoId);
 
     /**
+     * Get the forgot option used by {@link com.github.orangegangsters.lollipin.lib.managers.AppLockActivity}
+     */
+    public abstract boolean shouldShowForgot();
+
+    /**
+     * Set the forgot option used by {@link com.github.orangegangsters.lollipin.lib.managers.AppLockActivity}
+     */
+    public abstract void setShouldShowForgot(boolean showForgot);
+
+    /**
      * Enable the {@link com.github.orangegangsters.lollipin.lib.managers.AppLock} by setting
      * {@link com.github.orangegangsters.lollipin.lib.managers.AppLockImpl} as the
      * {@link com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface}

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -22,7 +22,7 @@ import com.github.orangegangsters.lollipin.lib.views.TypefaceTextView;
  * Call this activity in normal or singleTop mode (not singleTask or singleInstance, it does not work
  * with {@link android.app.Activity#startActivityForResult(android.content.Intent, int)}).
  */
-public abstract class AppLockActivity extends PinActivity implements KeyboardButtonClickedListener, View.OnClickListener {
+public class AppLockActivity extends PinActivity implements KeyboardButtonClickedListener, View.OnClickListener {
 
     public static final String TAG = "AppLockActivity";
     /**
@@ -87,11 +87,10 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             mType = extras.getInt(AppLock.EXTRA_TYPE, AppLock.UNLOCK_PIN);
         }
 
-        findViewById(R.id.pin_code_logo_imageview).setBackgroundResource(mLockManager.getAppLock().getLogoId());
         findViewById(R.id.pin_code_logo_imageview)
                 .setBackgroundResource(mLockManager.getAppLock().getLogoId());
-        TypefaceTextView forgot = (TypefaceTextView) findViewById(R.id.pin_code_forgot_textview);
-        forgot.setText(getForgotText());
+        mForgotTextView.setText(getForgotText());
+        mForgotTextView.setVisibility(mLockManager.getAppLock().shouldShowForgot() ? View.VISIBLE : View.GONE);
 
         initText();
     }
@@ -243,7 +242,9 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      * Displays the information dialog when the user clicks the
      * {@link #mForgotTextView}
      */
-    public abstract void showForgotDialog();
+    public void showForgotDialog() {
+
+    }
 
     /**
      * Run a shake animation when the password is not valid.

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -34,6 +34,10 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      */
     private static final String LOGO_ID_PREFERENCE_KEY = "LOGO_ID_PREFERENCE_KEY";
     /**
+     * The {@link android.content.SharedPreferences} key used to store the forgot option
+     */
+    private static final String SHOW_FORGOT_PREFERENCE_KEY = "SHOW_FORGOT_PREFERENCE_KEY";
+    /**
      * A string used to pollute the SHA1 password stored into
      * {@link android.content.SharedPreferences} for more security.
      */
@@ -80,6 +84,18 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     }
 
     @Override
+    public void setShouldShowForgot(boolean showForgot) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(SHOW_FORGOT_PREFERENCE_KEY, showForgot);
+        editor.apply();
+    }
+
+    @Override
+    public boolean shouldShowForgot() {
+        return mSharedPreferences.getBoolean(SHOW_FORGOT_PREFERENCE_KEY, true);
+    }
+
+    @Override
     public void enable() {
         PinActivity.setListener(this);
         PinFragmentActivity.setListener(this);
@@ -99,6 +115,7 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
                 .remove(LAST_ACTIVE_MILLIS_PREFERENCE_KEY)
                 .remove(TIMEOUT_MILLIS_PREFERENCE_KEY)
                 .remove(LOGO_ID_PREFERENCE_KEY)
+                .remove(SHOW_FORGOT_PREFERENCE_KEY)
                 .apply();
     }
 


### PR DESCRIPTION
This makes the 'forgot' button on the pin layout optional.

`Applock.setShouldShow(false)` will make the 'forgot' button View.GONE from the layout.

Squashed PR for "Feature/forgot optional #9"