### PR TITLE
New More Customizable Design

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -7,6 +7,7 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.github.orangegangsters.lollipin.lib.PinActivity;
@@ -36,6 +37,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     protected KeyboardView mKeyboardView;
     protected LockManager mLockManager;
     protected TypefaceTextView mForgotTextView;
+    protected LinearLayout mBackground;
 
     protected int mType = AppLock.UNLOCK_PIN;
     protected int mAttempts = 1;
@@ -80,6 +82,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         mPinCodeRoundView = (PinCodeRoundView) this.findViewById(R.id.pin_code_round_view);
         mForgotTextView = (TypefaceTextView) this.findViewById(R.id.pin_code_forgot_textview);
         mForgotTextView.setOnClickListener(this);
+        mBackground = (LinearLayout) this.findViewById(R.id.pin_code_background);
         mKeyboardView = (KeyboardView) this.findViewById(R.id.pin_code_keyboard_view);
         mKeyboardView.setKeyboardButtonClickedListener(this);
 
@@ -88,6 +91,9 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             mType = extras.getInt(AppLock.EXTRA_TYPE, AppLock.UNLOCK_PIN);
         }
 
+        mBackground.setBackgroundColor(getBackgroundColor());
+        mStepTextView.setTextColor(getTitleTextColor());
+
         int logoId = mLockManager.getAppLock().getLogoId();
         ImageView logoImage = ((ImageView)findViewById(R.id.pin_code_logo_imageview));
         if (logoId != AppLock.LOGO_ID_NONE) {
@@ -95,6 +101,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             logoImage.setImageResource(logoId);
         }
         mForgotTextView.setText(getForgotText());
+        mForgotTextView.setTextColor(getForgotTextColor());
         mForgotTextView.setVisibility(mLockManager.getAppLock().shouldShowForgot() ? View.VISIBLE : View.GONE);
 
         initText();
@@ -315,4 +322,28 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      * @param attempts the number of attempts the user had used
      */
     public abstract void onPinSuccess(int attempts);
+
+    /**
+     * Gets the {@link android.graphics.Color} of the top portion of the view.
+     * @return the background color
+     */
+    public int getBackgroundColor() {
+        return getResources().getColor(R.color.light_gray_bar);
+    }
+
+    /**
+     * Gets the {@link android.graphics.Color} of the main text on the view.
+     * @return the background color
+     */
+    public int getTitleTextColor() {
+        return getResources().getColor(R.color.dark_grey_color);
+    }
+
+    /**
+     * Gets the {@link android.graphics.Color} of the Forgot text on the view.
+     * @return the background color
+     */
+    public int getForgotTextColor() {
+        return getResources().getColor(R.color.dark_grey_color);
+    }
 }

--- a/lib/src/main/res/layout/activity_pin_code.xml
+++ b/lib/src/main/res/layout/activity_pin_code.xml
@@ -11,68 +11,65 @@
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/activity_pin_code_padding"
         android:paddingBottom="@dimen/activity_pin_code_padding"
         android:gravity="center_horizontal">
 
-        <ImageView
-            android:id="@+id/pin_code_logo_imageview"
-            android:layout_width="wrap_content"
+        <LinearLayout
+            android:id="@+id/pin_code_background"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/pin_code_logo_margin"
-            android:layout_alignParentTop="true"
-            android:layout_centerHorizontal="true"
-            android:visibility="invisible"
-            tools:visibility="visible"
-            tools:src="@android:drawable/sym_def_app_icon" />
+            android:paddingTop="@dimen/activity_pin_code_padding"
+            android:layout_marginBottom="@dimen/light_gray_bar_margin_bottom"
+            tools:background="@color/light_gray_bar"
+            android:orientation="vertical"
+            android:gravity="center_horizontal"
+            android:layout_alignParentTop="true" >
 
-        <com.github.orangegangsters.lollipin.lib.views.TypefaceTextView
-            android:id="@+id/pin_code_step_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:textColor="@color/dark_grey_color"
-            android:textSize="@dimen/pin_code_step_text_size"
-            android:layout_below="@+id/pin_code_logo_imageview"
-            app:typeface="Roboto-Light.ttf" />
+            <ImageView
+                android:id="@+id/pin_code_logo_imageview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/pin_code_logo_margin"
+                android:visibility="invisible"
+                tools:visibility="visible"
+                tools:src="@android:drawable/sym_def_app_icon" />
 
-        <com.github.orangegangsters.lollipin.lib.views.PinCodeRoundView
-            android:id="@+id/pin_code_round_view"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/pin_code_round_top_margin"
-            android:layout_marginBottom="@dimen/pin_code_elements_margin"
-            android:layout_below="@+id/pin_code_step_textview" />
+            <com.github.orangegangsters.lollipin.lib.views.TypefaceTextView
+                android:id="@+id/pin_code_step_textview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:textColor="@color/dark_grey_color"
+                android:textSize="@dimen/pin_code_step_text_size"
+                app:typeface="Roboto-Light.ttf" />
+
+            <com.github.orangegangsters.lollipin.lib.views.PinCodeRoundView
+                android:id="@+id/pin_code_round_view"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/pin_code_round_top_margin"
+                android:layout_marginBottom="@dimen/pin_code_elements_margin" />
+
+        </LinearLayout>
 
         <com.github.orangegangsters.lollipin.lib.views.TypefaceTextView
             android:id="@+id/pin_code_forgot_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:textColor="@color/dark_grey_color"
+            tools:textColor="@color/dark_grey_color"
             android:textSize="@dimen/pin_code_forgot_text_size"
             tools:text="@string/pin_code_forgot_text"
             android:singleLine="true"
             app:typeface="Roboto-Regular.ttf"
-            android:layout_below="@+id/pin_code_round_view" />
-
-        <LinearLayout
-            android:id="@+id/pin_code_gray_bar"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="@dimen/light_gray_bar_margin_top"
-            android:layout_marginBottom="@dimen/light_gray_bar_margin_bottom"
-            android:layout_marginLeft="@dimen/light_gray_bar_margin_sides"
-            android:layout_marginRight="@dimen/light_gray_bar_margin_sides"
-            android:background="@color/light_gray_bar"
-            android:orientation="horizontal"
-            android:layout_below="@+id/pin_code_forgot_textview" />
-
+            android:layout_alignParentBottom="true" />
+        
         <com.github.orangegangsters.lollipin.lib.views.KeyboardView
             android:id="@+id/pin_code_keyboard_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/pin_code_gray_bar" />
-
+            android:layout_below="@id/pin_code_background"
+            android:layout_above="@id/pin_code_forgot_textview"/>
+        
     </RelativeLayout>
+
 </ScrollView>


### PR DESCRIPTION
This slightly redesigns the lock screen to allow for more customization. It lets a user set a desired background color for the top portion of the screen (the screen that is not covered by the pin pad). It also allows for choosing the text color for the title and text color for the 'forgot?' text. 

The defaults are nearly unchanged. This lets you turn the default  this: 
![screenshot 2015-04-10 12 50 27](https://cloud.githubusercontent.com/assets/2646229/7095743/bdd7c6ca-df81-11e4-86d2-88f896516cb9.png)

into this:
![screenshot 2015-04-10 12 40 50](https://cloud.githubusercontent.com/assets/2646229/7095751/c900aa9e-df81-11e4-94a3-fc17f274a01d.png)

or any other sort of combination!

