### PR TITLE
Allows for custom handling of when the PinActivity is backable.

### DIFF
--- a/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
+++ b/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
@@ -9,7 +9,8 @@ import com.github.orangegangsters.lollipin.lib.views.PinCodeRoundView;
 import lollipin.orangegangsters.github.com.lollipin.R;
 
 /**
- * Created by stoyan and oliviergoutay on 1/13/15.
+ * @author stoyan and oliviergoutay
+ * @version 1/13/15
  */
 public class PinLockTest extends AbstractTest {
 
@@ -173,6 +174,33 @@ public class PinLockTest extends AbstractTest {
         solo.sleep(1000);
     }
 
+    public void testBackButton() {
+        enablePin();
+
+        //Go to unlock
+        clickOnView(R.id.button_unlock_pin);
+        solo.waitForActivity(CustomPinActivity.class);
+        solo.assertCurrentActivity("CustomPinActivity", CustomPinActivity.class);
+
+        solo.goBack();
+        solo.assertCurrentActivity("CustomPinActivity", CustomPinActivity.class);
+
+        //reset
+        clickOnView(R.id.pin_code_button_1);
+        clickOnView(R.id.pin_code_button_2);
+        clickOnView(R.id.pin_code_button_3);
+        clickOnView(R.id.pin_code_button_4);
+        solo.sleep(1000);
+
+        //Go to change
+        clickOnView(R.id.button_change_pin);
+        solo.waitForActivity(CustomPinActivity.class);
+        solo.assertCurrentActivity("CustomPinActivity", CustomPinActivity.class);
+
+        solo.goBack();
+        solo.assertCurrentActivity("MainActivity", MainActivity.class);
+    }
+
     private void enablePin() {
         removePrefsAndGoToEnable();
 
@@ -201,5 +229,4 @@ public class PinLockTest extends AbstractTest {
             solo.waitForText("1");
         }
     }
-
 }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -17,6 +17,9 @@ import com.github.orangegangsters.lollipin.lib.views.KeyboardView;
 import com.github.orangegangsters.lollipin.lib.views.PinCodeRoundView;
 import com.github.orangegangsters.lollipin.lib.views.TypefaceTextView;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Created by stoyan and olivier on 1/13/15.
  * The activity that appears when the password needs to be set or has to be asked.
@@ -245,9 +248,18 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onBackPressed() {
-        if (mType == AppLock.CHANGE_PIN || mType == AppLock.DISABLE_PINLOCK) {
+        if (getBackableTypes().contains(mType)) {
             super.onBackPressed();
         }
+    }
+
+    /**
+     * Gets the list of {@link AppLock} types that are acceptable to be backed out of using
+     * the device's back button
+     * @return an {@link List<Integer>} of {@link AppLock} types which are backable
+     */
+    public List<Integer> getBackableTypes() {
+        return Arrays.asList(AppLock.CHANGE_PIN, AppLock.DISABLE_PINLOCK);
     }
 
     /**


### PR DESCRIPTION
This will let a client app customize which AppLock Types are able to be backed out of using the Android Back Button without sacrificing existing functionality. 