### PR TITLE
Migrates PinCode 'Clear' button to a more common 'back' button functiona...

### DIFF
--- a/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
+++ b/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
@@ -32,7 +32,7 @@ public class PinLockTest extends AbstractTest {
 
         //Check length 0
         solo.sleep(1000);
-        assertEquals(0, pinCodeRoundView.getCurrentLength());
+        assertEquals(2, pinCodeRoundView.getCurrentLength());
     }
 
     public void testPinEnabling() {

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -166,7 +166,11 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             int value = keyboardButtonEnum.getButtonValue();
 
             if (value == KeyboardButtonEnum.BUTTON_CLEAR.getButtonValue()) {
-                setPinCode("");
+                if (!mPinCode.isEmpty()) {
+                    setPinCode(mPinCode.substring(0, mPinCode.length() - 1));
+                } else {
+                    setPinCode("");
+                }
             } else {
                 setPinCode(mPinCode + value);
             }


### PR DESCRIPTION
...lity.

Using Google Wallet as an example it is much more common for the "<x]" button to clear the last entered entry and not the entire entered pin. 

![screenshot_2015-04-20-14-09-55](https://cloud.githubusercontent.com/assets/2646229/7240717/0109f696-e768-11e4-96d5-a154e88ea4de.png)

Tests updated and passing:

![screenshot 2015-04-20 14 16 57](https://cloud.githubusercontent.com/assets/2646229/7240704/e6175aa4-e767-11e4-8b22-fff4563f782b.png)