### PR TITLE
Allows for proper finish()ing of Activities when the AppLockActivity is ...

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/PinActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/PinActivity.java
@@ -1,8 +1,15 @@
 package com.github.orangegangsters.lollipin.lib;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 
 import com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface;
+import com.github.orangegangsters.lollipin.lib.managers.AppLockActivity;
 
 /**
  * Created by stoyan and olivier on 1/12/15.
@@ -12,6 +19,24 @@ import com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface;
  */
 public class PinActivity extends Activity {
     private static LifeCycleInterface mLifeCycleListener;
+    private final BroadcastReceiver mPinCancelledReceiver;
+
+    public PinActivity() {
+        super();
+        mPinCancelledReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        };
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        IntentFilter filter = new IntentFilter(AppLockActivity.ACTION_CANCEL);
+        LocalBroadcastManager.getInstance(this).registerReceiver(mPinCancelledReceiver, filter);
+    }
 
     @Override
     protected void onResume() {
@@ -27,6 +52,12 @@ public class PinActivity extends Activity {
             mLifeCycleListener.onActivityPaused(PinActivity.this);
         }
         super.onPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mPinCancelledReceiver);
     }
 
     public static void setListener(LifeCycleInterface listener) {

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/PinFragmentActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/PinFragmentActivity.java
@@ -1,8 +1,15 @@
 package com.github.orangegangsters.lollipin.lib;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
+import android.support.v4.content.LocalBroadcastManager;
 
 import com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface;
+import com.github.orangegangsters.lollipin.lib.managers.AppLockActivity;
 
 /**
  * Created by stoyan and olivier on 1/12/15.
@@ -12,6 +19,24 @@ import com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface;
  */
 public class PinFragmentActivity extends FragmentActivity {
     private static LifeCycleInterface mLifeCycleListener;
+    private final BroadcastReceiver mPinCancelledReceiver;
+
+    public PinFragmentActivity() {
+        super();
+        mPinCancelledReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                finish();
+            }
+        };
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        IntentFilter filter = new IntentFilter(AppLockActivity.ACTION_CANCEL);
+        LocalBroadcastManager.getInstance(this).registerReceiver(mPinCancelledReceiver, filter);
+    }
 
     @Override
     protected void onResume() {
@@ -27,6 +52,12 @@ public class PinFragmentActivity extends FragmentActivity {
             mLifeCycleListener.onActivityPaused(PinFragmentActivity.this);
         }
         super.onPause();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mPinCancelledReceiver);
     }
 
     public static void setListener(LifeCycleInterface listener) {

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -103,6 +103,16 @@ public abstract class AppLock {
     public abstract void setShouldShowForgot(boolean showForgot);
 
     /**
+     * Get whether the user backed out of the {@link AppLockActivity} previously
+     */
+    public abstract boolean pinChallengeCancelled();
+
+    /**
+     * Set whether the user backed out of the {@link AppLockActivity}
+     */
+    public abstract void setPinChallengeCancelled(boolean cancelled);
+
+    /**
      * Enable the {@link com.github.orangegangsters.lollipin.lib.managers.AppLock} by setting
      * {@link com.github.orangegangsters.lollipin.lib.managers.AppLockImpl} as the
      * {@link com.github.orangegangsters.lollipin.lib.interfaces.LifeCycleInterface}

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -3,6 +3,7 @@ package com.github.orangegangsters.lollipin.lib.managers;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -29,6 +30,7 @@ import java.util.List;
 public abstract class AppLockActivity extends PinActivity implements KeyboardButtonClickedListener, View.OnClickListener {
 
     public static final String TAG = AppLockActivity.class.getSimpleName();
+    public static final String ACTION_CANCEL = TAG + ".actionCancelled";
     /**
      * The PIN length
      */
@@ -78,6 +80,8 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         mLockManager = LockManager.getInstance();
         mPinCode = "";
         mOldPinCode = "";
+
+        mLockManager.getAppLock().setPinChallengeCancelled(false);
 
         mStepTextView = (TextView) this.findViewById(R.id.pin_code_step_textview);
         mPinCodeRoundView = (PinCodeRoundView) this.findViewById(R.id.pin_code_round_view);
@@ -253,6 +257,12 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     @Override
     public void onBackPressed() {
         if (getBackableTypes().contains(mType)) {
+            if (AppLock.UNLOCK_PIN == getType()) {
+                mLockManager.getAppLock().setPinChallengeCancelled(true);
+                LocalBroadcastManager
+                        .getInstance(this)
+                        .sendBroadcast(new Intent().setAction(ACTION_CANCEL));
+            }
             super.onBackPressed();
         }
     }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -47,6 +47,10 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      */
     private static final String SHOW_FORGOT_PREFERENCE_KEY = "SHOW_FORGOT_PREFERENCE_KEY";
     /**
+     * The {@link SharedPreferences} key used to store whether the user has backed out of the {@link AppLockActivity}
+     */
+    private static final String PIN_CHALLENGE_CANCELLED_PREFERENCE_KEY = "PIN_CHALLENGE_CANCELLED_PREFERENCE_KEY";
+    /**
      * The {@link android.content.SharedPreferences} key used to store the dynamically generated password salt
      */
     private static final String PASSWORD_SALT_PREFERENCE_KEY = "PASSWORD_SALT_PREFERENCE_KEY";
@@ -143,6 +147,18 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     public void setShouldShowForgot(boolean showForgot) {
         SharedPreferences.Editor editor = mSharedPreferences.edit();
         editor.putBoolean(SHOW_FORGOT_PREFERENCE_KEY, showForgot);
+        editor.apply();
+    }
+
+    @Override
+    public boolean pinChallengeCancelled() {
+        return mSharedPreferences.getBoolean(PIN_CHALLENGE_CANCELLED_PREFERENCE_KEY, false);
+    }
+
+    @Override
+    public void setPinChallengeCancelled(boolean backedOut) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(PIN_CHALLENGE_CANCELLED_PREFERENCE_KEY, backedOut);
         editor.apply();
     }
 
@@ -250,6 +266,11 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     @Override
     public boolean shouldLockSceen(Activity activity) {
         Log.d(TAG, "Lollipin shouldLockSceen() called");
+
+        // previously backed out of pin screen
+        if (pinChallengeCancelled()) {
+            return true;
+        }
 
         // already unlock
         if (activity instanceof AppLockActivity) {


### PR DESCRIPTION
...onBackPressed().

- If a subclass of AppLockActivity allows for backing out of the AppLock.UNLOCK_PIN then this better handles that scenario. 
- Enables all classes that extend from PinFragmentActivity or PinActivity to listen for a local broadcast for when the user backs out of entering their pin. When this happens the Activities are finish()ed. 
- Adds pinChallengeCancelled to AppLock to ensure that rapid exiting and entering of the AppLockActivity does not bypass the challenge. 