### PR TITLE
Allow for custom PIN length

### DIFF
--- a/app/src/main/java/com/github/orangegangsters/lollipin/CustomPinActivity.java
+++ b/app/src/main/java/com/github/orangegangsters/lollipin/CustomPinActivity.java
@@ -72,4 +72,9 @@ public class CustomPinActivity extends AppLockActivity {
     public void onPinSuccess(int attempts) {
 
     }
+
+    @Override
+    public int getPinMaxLength() {
+        return 4;
+    }
 }

--- a/app/src/main/java/com/github/orangegangsters/lollipin/CustomPinActivity.java
+++ b/app/src/main/java/com/github/orangegangsters/lollipin/CustomPinActivity.java
@@ -72,9 +72,4 @@ public class CustomPinActivity extends AppLockActivity {
     public void onPinSuccess(int attempts) {
 
     }
-
-    @Override
-    public int getPinMaxLength() {
-        return 4;
-    }
 }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -31,10 +31,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
 
     public static final String TAG = AppLockActivity.class.getSimpleName();
     public static final String ACTION_CANCEL = TAG + ".actionCancelled";
-    /**
-     * The PIN length
-     */
-    private static final int DEFAULT_PIN_MAX_LENGTH = 4;
+    private static final int DEFAULT_PIN_LENGTH = 4;
 
     protected TextView mStepTextView;
     protected TextView mForgotTextView;
@@ -85,7 +82,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
 
         mStepTextView = (TextView) this.findViewById(R.id.pin_code_step_textview);
         mPinCodeRoundView = (PinCodeRoundView) this.findViewById(R.id.pin_code_round_view);
-        mPinCodeRoundView.setPinMaxLength(this.getPinMaxLength());
+        mPinCodeRoundView.setPinLength(this.getPinLength());
         mForgotTextView = (TypefaceTextView) this.findViewById(R.id.pin_code_forgot_textview);
         mForgotTextView.setOnClickListener(this);
         mKeyboardView = (KeyboardView) this.findViewById(R.id.pin_code_keyboard_view);
@@ -124,19 +121,19 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         String msg = null;
         switch (reason) {
             case AppLock.DISABLE_PINLOCK:
-                msg = getString(R.string.pin_code_step_disable, this.getPinMaxLength());
+                msg = getString(R.string.pin_code_step_disable, this.getPinLength());
                 break;
             case AppLock.ENABLE_PINLOCK:
-                msg = getString(R.string.pin_code_step_create, this.getPinMaxLength());
+                msg = getString(R.string.pin_code_step_create, this.getPinLength());
                 break;
             case AppLock.CHANGE_PIN:
-                msg = getString(R.string.pin_code_step_change, this.getPinMaxLength());
+                msg = getString(R.string.pin_code_step_change, this.getPinLength());
                 break;
             case AppLock.UNLOCK_PIN:
-                msg = getString(R.string.pin_code_step_unlock, this.getPinMaxLength());
+                msg = getString(R.string.pin_code_step_unlock, this.getPinLength());
                 break;
             case AppLock.CONFIRM_PIN:
-                msg = getString(R.string.pin_code_step_enable_confirm, this.getPinMaxLength());
+                msg = getString(R.string.pin_code_step_enable_confirm, this.getPinLength());
                 break;
         }
         return msg;
@@ -170,7 +167,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onKeyboardClick(KeyboardButtonEnum keyboardButtonEnum) {
-        if (mPinCode.length() < this.getPinMaxLength()) {
+        if (mPinCode.length() < this.getPinLength()) {
             int value = keyboardButtonEnum.getButtonValue();
 
             if (value == KeyboardButtonEnum.BUTTON_CLEAR.getButtonValue()) {
@@ -191,7 +188,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onRippleAnimationEnd() {
-        if (mPinCode.length() == this.getPinMaxLength()) {
+        if (mPinCode.length() == this.getPinLength()) {
             onPinCodeInputed();
         }
     }
@@ -362,9 +359,9 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     /**
      * Gets the number of digits in the pin code.  Subclasses can override this to change the
      * length of the pin.
-     * @return the number of digits
+     * @return the number of digits in the PIN
      */
-    public int getPinMaxLength() {
-        return AppLockActivity.DEFAULT_PIN_MAX_LENGTH;
+    public int getPinLength() {
+        return AppLockActivity.DEFAULT_PIN_LENGTH;
     }
 }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -34,7 +34,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     /**
      * The PIN length
      */
-    private static final int PIN_CODE_LENGTH = 4;
+    private static final int DEFAULT_PIN_MAX_LENGTH = 4;
 
     protected TextView mStepTextView;
     protected TextView mForgotTextView;
@@ -85,6 +85,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
 
         mStepTextView = (TextView) this.findViewById(R.id.pin_code_step_textview);
         mPinCodeRoundView = (PinCodeRoundView) this.findViewById(R.id.pin_code_round_view);
+        mPinCodeRoundView.setPinMaxLength(this.getPinMaxLength());
         mForgotTextView = (TypefaceTextView) this.findViewById(R.id.pin_code_forgot_textview);
         mForgotTextView.setOnClickListener(this);
         mKeyboardView = (KeyboardView) this.findViewById(R.id.pin_code_keyboard_view);
@@ -123,19 +124,19 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         String msg = null;
         switch (reason) {
             case AppLock.DISABLE_PINLOCK:
-                msg = getString(R.string.pin_code_step_disable);
+                msg = getString(R.string.pin_code_step_disable, this.getPinMaxLength());
                 break;
             case AppLock.ENABLE_PINLOCK:
-                msg = getString(R.string.pin_code_step_create);
+                msg = getString(R.string.pin_code_step_create, this.getPinMaxLength());
                 break;
             case AppLock.CHANGE_PIN:
-                msg = getString(R.string.pin_code_step_change);
+                msg = getString(R.string.pin_code_step_change, this.getPinMaxLength());
                 break;
             case AppLock.UNLOCK_PIN:
-                msg = getString(R.string.pin_code_step_unlock);
+                msg = getString(R.string.pin_code_step_unlock, this.getPinMaxLength());
                 break;
             case AppLock.CONFIRM_PIN:
-                msg = getString(R.string.pin_code_step_enable_confirm);
+                msg = getString(R.string.pin_code_step_enable_confirm, this.getPinMaxLength());
                 break;
         }
         return msg;
@@ -169,7 +170,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onKeyboardClick(KeyboardButtonEnum keyboardButtonEnum) {
-        if (mPinCode.length() < PIN_CODE_LENGTH) {
+        if (mPinCode.length() < this.getPinMaxLength()) {
             int value = keyboardButtonEnum.getButtonValue();
 
             if (value == KeyboardButtonEnum.BUTTON_CLEAR.getButtonValue()) {
@@ -190,7 +191,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     @Override
     public void onRippleAnimationEnd() {
-        if (mPinCode.length() == PIN_CODE_LENGTH) {
+        if (mPinCode.length() == this.getPinMaxLength()) {
             onPinCodeInputed();
         }
     }
@@ -356,5 +357,14 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     public int getContentView() {
         return R.layout.activity_pin_code;
+    }
+
+    /**
+     * Gets the number of digits in the pin code.  Subclasses can override this to change the
+     * length of the pin.
+     * @return the number of digits
+     */
+    public int getPinMaxLength() {
+        return AppLockActivity.DEFAULT_PIN_MAX_LENGTH;
     }
 }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
@@ -5,6 +5,7 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
+import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 
@@ -24,6 +25,7 @@ public class PinCodeRoundView extends RelativeLayout {
     private int mCurrentLength;
     private Drawable mEmptyDotDrawableId;
     private Drawable mFullDotDrawableId;
+    private ViewGroup mRoundContainer;
 
     public PinCodeRoundView(Context context) {
         this(context, null);
@@ -56,14 +58,9 @@ public class PinCodeRoundView extends RelativeLayout {
 
             LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             PinCodeRoundView view = (PinCodeRoundView) inflater.inflate(R.layout.view_round_pin_code, this);
+            mRoundContainer = (ViewGroup) view.findViewById( R.id.round_container );
 
             mRoundViews = new ArrayList<>();
-            mRoundViews.add((ImageView) view.findViewById(R.id.pin_code_round1));
-            mRoundViews.add((ImageView) view.findViewById(R.id.pin_code_round2));
-            mRoundViews.add((ImageView) view.findViewById(R.id.pin_code_round3));
-            mRoundViews.add((ImageView) view.findViewById(R.id.pin_code_round4));
-
-            refresh(0);
         }
     }
 
@@ -117,5 +114,20 @@ public class PinCodeRoundView extends RelativeLayout {
      */
     public void setFullDotDrawable(int drawableId) {
         mFullDotDrawableId = getResources().getDrawable(drawableId);
+    }
+
+    /**
+     * Sets the maximum length of the pin code.
+     *
+     * @param pinMaxLength the max length of the pin code
+     */
+    public void setPinMaxLength(int pinMaxLength) {
+        LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        for (int i = 0; i < pinMaxLength; i++) {
+            ImageView roundView = (ImageView) inflater.inflate(R.layout.view_round, mRoundContainer, false);
+            mRoundContainer.addView(roundView);
+            mRoundViews.add(roundView);
+        }
+        refresh(0);
     }
 }

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
@@ -117,13 +117,13 @@ public class PinCodeRoundView extends RelativeLayout {
     }
 
     /**
-     * Sets the maximum length of the pin code.
+     * Sets the length of the pin code.
      *
-     * @param pinMaxLength the max length of the pin code
+     * @param pinLength the length of the pin code
      */
-    public void setPinMaxLength(int pinMaxLength) {
+    public void setPinLength(int pinLength) {
         LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        for (int i = 0; i < pinMaxLength; i++) {
+        for (int i = 0; i < pinLength; i++) {
             ImageView roundView = (ImageView) inflater.inflate(R.layout.view_round, mRoundContainer, false);
             mRoundContainer.addView(roundView);
             mRoundViews.add(roundView);

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/SquareImageView.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/SquareImageView.java
@@ -1,0 +1,33 @@
+package com.github.orangegangsters.lollipin.lib.views;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+
+/**
+ * An ImageView that shrinks its larger dimension to become square.
+ */
+public class SquareImageView extends ImageView {
+    public SquareImageView(Context context) {
+        super(context);
+    }
+
+    public SquareImageView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @SuppressWarnings("SuspiciousNameCombination")
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+
+        int measuredWidth = this.getMeasuredWidth();
+        int measuredHeight = this.getMeasuredHeight();
+
+        if (measuredHeight > measuredWidth) {
+            this.setMeasuredDimension(measuredWidth, measuredWidth);
+        } else {
+            this.setMeasuredDimension(measuredHeight, measuredHeight);
+        }
+    }
+}

--- a/lib/src/main/res/layout/view_round.xml
+++ b/lib/src/main/res/layout/view_round.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.github.orangegangsters.lollipin.lib.views.SquareImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/pin_code_round"
+    android:layout_width="0dp"
+    android:layout_height="@dimen/pin_code_round_size"
+    android:layout_margin="@dimen/pin_code_round_margin"
+    android:layout_weight="1"
+    android:maxHeight="@dimen/pin_code_round_size"
+    android:maxWidth="@dimen/pin_code_round_size"
+    tools:src="@drawable/pin_code_round_empty" />

--- a/lib/src/main/res/layout/view_round_pin_code.xml
+++ b/lib/src/main/res/layout/view_round_pin_code.xml
@@ -1,38 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="horizontal"
+    android:id="@+id/round_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:gravity="center">
-
-    <ImageView
-        android:id="@+id/pin_code_round1"
-        android:layout_width="@dimen/pin_code_round_size"
-        android:layout_height="@dimen/pin_code_round_size"
-        tools:src="@drawable/pin_code_round_empty"
-        android:layout_margin="@dimen/pin_code_round_margin" />
-
-    <ImageView
-        android:id="@+id/pin_code_round2"
-        android:layout_width="@dimen/pin_code_round_size"
-        android:layout_height="@dimen/pin_code_round_size"
-        tools:src="@drawable/pin_code_round_empty"
-        android:layout_margin="@dimen/pin_code_round_margin" />
-
-    <ImageView
-        android:id="@+id/pin_code_round3"
-        android:layout_width="@dimen/pin_code_round_size"
-        android:layout_height="@dimen/pin_code_round_size"
-        tools:src="@drawable/pin_code_round_empty"
-        android:layout_margin="@dimen/pin_code_round_margin" />
-
-    <ImageView
-        android:id="@+id/pin_code_round4"
-        android:layout_width="@dimen/pin_code_round_size"
-        android:layout_height="@dimen/pin_code_round_size"
-        tools:src="@drawable/pin_code_round_empty"
-        android:layout_margin="@dimen/pin_code_round_margin" />
+    android:gravity="center"
+    android:orientation="horizontal">
 
 </LinearLayout>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -21,9 +21,9 @@
     <string name="button11_large_text">0</string>
 
     <string name="pin_code_forgot_text">Forgot?</string>
-    <string name="pin_code_step_disable">Disable 4-digit Pincode</string>
-    <string name="pin_code_step_create">Create a 4-digit Pincode</string>
-    <string name="pin_code_step_change">Enter your current 4-digit Pincode</string>
-    <string name="pin_code_step_unlock">Enter your 4-digit Pincode</string>
-    <string name="pin_code_step_enable_confirm">Confirm your 4-digit Pincode</string>
+    <string name="pin_code_step_disable">Disable %d-digit Pincode</string>
+    <string name="pin_code_step_create">Create a %d-digit Pincode</string>
+    <string name="pin_code_step_change">Enter your current %d-digit Pincode</string>
+    <string name="pin_code_step_unlock">Enter your %d-digit Pincode</string>
+    <string name="pin_code_step_enable_confirm">Confirm your %d-digit Pincode</string>
 </resources>


### PR DESCRIPTION
- The PIN length can be changed by overriding AppLockActivity.getPinMaxLength() to return the desired PIN size.  The size defaults to 4.
- PinCodeRoundView now adds circle images dynamically based on PIN length, and will shrink their size once they start to overflow the screen width.
- Added PIN length argument to strings which mentioned "4-digit Pincode"