### PR TITLE
Added ability to disable use of fingerprint sensor on devices that su…

### DIFF
--- a/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
+++ b/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
@@ -14,6 +14,7 @@ import com.github.orangegangsters.lollipin.MainActivity;
 import com.github.orangegangsters.lollipin.NotLockedActivity;
 import com.github.orangegangsters.lollipin.lib.encryption.Encryptor;
 import com.github.orangegangsters.lollipin.lib.enums.Algorithm;
+import com.github.orangegangsters.lollipin.lib.managers.AppLock;
 import com.github.orangegangsters.lollipin.lib.managers.AppLockImpl;
 import com.github.orangegangsters.lollipin.lib.managers.FingerprintUiHelper;
 import com.github.orangegangsters.lollipin.lib.managers.LockManager;
@@ -254,6 +255,32 @@ public class PinLockTest extends AbstractTest {
         solo.assertCurrentActivity("CustomPinActivity", CustomPinActivity.class);
 
         solo.goBack();
+        solo.assertCurrentActivity("MainActivity", MainActivity.class);
+    }
+
+    public void testDisablingFingerprintReader() {
+        enablePin();
+
+        // Disable fingerprint reader.
+        LockManager.getInstance().getAppLock().setFingerprintAuthEnabled(false);
+
+        // Go to unlock.
+        clickOnView(R.id.button_unlock_pin);
+        solo.waitForActivity(CustomPinActivity.class);
+        solo.assertCurrentActivity("CustomPinActivity", CustomPinActivity.class);
+
+        // Make sure the fingerprint views are gone.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            assertEquals(View.GONE, solo.getView(R.id.pin_code_fingerprint_imageview).getVisibility());
+            assertEquals(View.GONE, solo.getView(R.id.pin_code_fingerprint_textview).getVisibility());
+        }
+
+        // Make sure pin unlocking still works.
+        clickOnView(R.id.pin_code_button_1);
+        clickOnView(R.id.pin_code_button_2);
+        clickOnView(R.id.pin_code_button_3);
+        clickOnView(R.id.pin_code_button_4);
+        solo.waitForActivity(MainActivity.class);
         solo.assertCurrentActivity("MainActivity", MainActivity.class);
     }
 

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -151,6 +151,19 @@ public abstract class AppLock {
     public abstract boolean setPasscode(String passcode);
 
     /**
+     * Check the {@link android.content.SharedPreferences} to see if fingerprint authentication is
+     * enabled.
+     */
+    public abstract boolean isFingerprintAuthEnabled();
+
+    /**
+     * Enable or disable fingerprint authentication on the PIN screen.
+     * @param enabled If true, enables the fingerprint reader if it is supported.  If false, will
+     *                hide the fingerprint reader icon on the PIN screen.
+     */
+    public abstract void setFingerprintAuthEnabled(boolean enabled);
+
+    /**
      * Check the passcode by comparing his SHA1 into {@link android.content.SharedPreferences} using the
      * {@link com.github.orangegangsters.lollipin.lib.encryption.Encryptor} class.
      */

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockActivity.java
@@ -144,7 +144,8 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             mFingerprintManager = (FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE);
             mFingerprintUiHelper = new FingerprintUiHelper.FingerprintUiHelperBuilder(mFingerprintManager).build(mFingerprintImageView, mFingerprintTextView, this);
             try {
-                if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()) {
+            if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
+                    && mLockManager.getAppLock().isFingerprintAuthEnabled()) {
                     mFingerprintImageView.setVisibility(View.VISIBLE);
                     mFingerprintTextView.setVisibility(View.VISIBLE);
                     mFingerprintUiHelper.startListening();

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -55,7 +55,11 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      * The {@link android.content.SharedPreferences} key used to store the dynamically generated password salt
      */
     private static final String PASSWORD_SALT_PREFERENCE_KEY = "PASSWORD_SALT_PREFERENCE_KEY";
-
+    /**
+     * The {@link SharedPreferences} key used to store whether the caller has enabled fingerprint authentication.
+     * This value defaults to true for backwards compatibility.
+     */
+    private static final String FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY = "FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY";
     /**
      * The default password salt
      */
@@ -211,12 +215,25 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
                 .remove(TIMEOUT_MILLIS_PREFERENCE_KEY)
                 .remove(LOGO_ID_PREFERENCE_KEY)
                 .remove(SHOW_FORGOT_PREFERENCE_KEY)
+                .remove(FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY)
                 .apply();
     }
 
     @Override
     public long getLastActiveMillis() {
         return mSharedPreferences.getLong(LAST_ACTIVE_MILLIS_PREFERENCE_KEY, 0);
+    }
+
+    @Override
+    public boolean isFingerprintAuthEnabled() {
+        return mSharedPreferences.getBoolean(FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY, true);
+    }
+
+    @Override
+    public void setFingerprintAuthEnabled(boolean enabled) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY, enabled);
+        editor.apply();
     }
 
     @Override


### PR DESCRIPTION
…pport it.

I've added a simple boolean preference and a quick call to allow the caller to disable using the fingerprint reader to dismiss the PIN screen.  We have a requirement to support multiple logins on the same device, and to disable the reader if the user specifies.  

I've run the tests in both the application and in the library, and they pass.  It would be nice to merge this into the main library, so let me know if there's something else I need to do to make this happen.

Thanks,
Kevin