### PR TITLE
Background timeout only

### DIFF
--- a/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/AbstractTest.java
+++ b/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/AbstractTest.java
@@ -17,6 +17,7 @@ public class AbstractTest extends ActivityInstrumentationTestCase2<MainActivity>
     protected static final String PASSWORD_PREFERENCE_KEY = "PASSCODE";
     protected static final String PASSWORD_ALGORITHM_PREFERENCE_KEY = "ALGORITHM";
     private static final String LAST_ACTIVE_MILLIS_PREFERENCE_KEY = "LAST_ACTIVE_MILLIS";
+    protected static final String ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY = "ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY";
 
     protected Solo solo;
 

--- a/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
+++ b/app/src/androidTest/java/lollipin/orangegangsters/github/com/lollipin/functional/PinLockTest.java
@@ -230,6 +230,31 @@ public class PinLockTest extends AbstractTest {
         solo.sleep(1000);
     }
 
+    public void testPinLockWithBackgroundTimeout() {
+        enablePin();
+
+        // Set the option to use timeout in background only
+        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putBoolean(ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY, true);
+        editor.apply();
+
+        //Go to NotLockedActivity
+        solo.sleep(1000);
+        clickOnView(R.id.button_not_locked);
+        solo.waitForActivity(NotLockedActivity.class);
+        solo.assertCurrentActivity("NotLockedActivity", NotLockedActivity.class);
+
+        //Set the last time to now - 15sec
+        setMillis(System.currentTimeMillis() - (1000 * 15));
+        solo.getCurrentActivity().finish();
+
+        //Check view
+        solo.waitForActivity(MainActivity.class);
+        solo.assertCurrentActivity("MainActivity", MainActivity.class);
+        solo.sleep(1000);
+    }
+
     public void testBackButton() {
         enablePin();
 

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLock.java
@@ -112,6 +112,18 @@ public abstract class AppLock {
      */
     public abstract void setPinChallengeCancelled(boolean cancelled);
 
+
+    /**
+     * Get the only background timeout option used to determine if the time
+     * spent in the activity must NOT be taken into account while calculating the timeout.
+     */
+    public abstract boolean onlyBackgroundTimeout();
+
+    /**
+     * Set whether the time spent on the activity must NOT be taken into account when calculating timeout.
+     */
+    public abstract void setOnlyBackgroundTimeout(boolean onlyBackgroundTimeout);
+
     /**
      * Enable the {@link com.github.orangegangsters.lollipin.lib.managers.AppLock} by setting
      * {@link com.github.orangegangsters.lollipin.lib.managers.AppLockImpl} as the

--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/managers/AppLockImpl.java
@@ -47,6 +47,11 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      * The {@link android.content.SharedPreferences} key used to store the forgot option
      */
     private static final String SHOW_FORGOT_PREFERENCE_KEY = "SHOW_FORGOT_PREFERENCE_KEY";
+
+    /**
+     * The {@link android.content.SharedPreferences} key used to store the only background timeout option
+     */
+    private static final String ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY = "ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY";
     /**
      * The {@link SharedPreferences} key used to store whether the user has backed out of the {@link AppLockActivity}
      */
@@ -184,6 +189,18 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
     @Override
     public boolean shouldShowForgot() {
         return mSharedPreferences.getBoolean(SHOW_FORGOT_PREFERENCE_KEY, true);
+    }
+
+    @Override
+    public boolean onlyBackgroundTimeout() {
+        return mSharedPreferences.getBoolean(ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY, false);
+    }
+
+    @Override
+    public void setOnlyBackgroundTimeout(boolean onlyBackgroundTimeout) {
+        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        editor.putBoolean(ONLY_BACKGROUND_TIMEOUT_PREFERENCE_KEY, onlyBackgroundTimeout);
+        editor.apply();
     }
 
     @Override
@@ -344,7 +361,7 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
         String clazzName = activity.getClass().getName();
         Log.d(TAG, "onActivityPaused " + clazzName);
 
-        if (!shouldLockSceen(activity) && !(activity instanceof AppLockActivity)) {
+        if ((onlyBackgroundTimeout() || !shouldLockSceen(activity)) && !(activity instanceof AppLockActivity)) {
             setLastActiveMillis();
         }
     }


### PR DESCRIPTION
Added the possibility to lock only after background.
This is what was wanted in #82. 