### PR TITLE
Keyboard LinearLayout

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/KeyboardView.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/KeyboardView.java
@@ -5,7 +5,7 @@ import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.widget.RelativeLayout;
+import android.widget.LinearLayout;
 
 import com.github.orangegangsters.lollipin.lib.R;
 import com.github.orangegangsters.lollipin.lib.enums.KeyboardButtonEnum;
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Created by stoyan and olivier on 1/13/15.
  */
-public class KeyboardView extends RelativeLayout implements View.OnClickListener {
+public class KeyboardView extends LinearLayout implements View.OnClickListener {
 
     private Context mContext;
     private KeyboardButtonClickedListener mKeyboardButtonClickedListener;

--- a/lib/src/main/res/layout/view_keyboard.xml
+++ b/lib/src/main/res/layout/view_keyboard.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <LinearLayout android:id="@+id/pin_code_first_row"
         android:layout_width="match_parent"
@@ -124,4 +124,4 @@
 
     </LinearLayout>
 
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
Changed the KeyboardView to use LinearLayout. It's simpler and quicker and no RelativeLayout abilities was actually used here.

Made the view_keyboard wrap_content to have the better UI overriding possibilities.
I had the problem with creating custom UI where i wanted add spaces with layout_weight and it was not possible because of match_parent atrribute in the view_keyboard.xml.