### PR TITLE
Remove existing RoundPin when setPinLength is called

### DIFF
--- a/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
+++ b/lib/src/main/java/com/github/orangegangsters/lollipin/lib/views/PinCodeRoundView.java
@@ -123,11 +123,20 @@ public class PinCodeRoundView extends RelativeLayout {
      */
     public void setPinLength(int pinLength) {
         LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        mRoundContainer.removeAllViews();
+        List<ImageView> temp = new ArrayList<>(pinLength);
         for (int i = 0; i < pinLength; i++) {
-            ImageView roundView = (ImageView) inflater.inflate(R.layout.view_round, mRoundContainer, false);
+            ImageView roundView;
+            if (i < mRoundViews.size()) {
+                roundView = mRoundViews.get(i);
+            } else {
+                roundView = (ImageView) inflater.inflate(R.layout.view_round, mRoundContainer, false);
+            }
             mRoundContainer.addView(roundView);
-            mRoundViews.add(roundView);
+            temp.add(roundView);
         }
+        mRoundViews.clear();
+        mRoundViews.addAll(temp);
         refresh(0);
     }
 }


### PR DESCRIPTION
This fixes a case where number of round pin are displayed are double the pin length.
`AppLockActivity` is set as singleTop mode causing `initLayout()` called twice, once in `onCreate()` and `onNewIntent()`. Since `setupPinLength()` did not clear existing Views, it adds another set of round pin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/orangegangsters/lollipin/113)
<!-- Reviewable:end -->
