### PR TITLE
Persist number of login attempts to prevent brute-force attack

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     compile project(':lib')
-    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile 'androidx.appcompat:appcompat:1.0.0'
 
     //Lollipop dialogs https://github.com/lewisjdeane/L-Dialogs and buttons, animations etc...
     compile 'uk.me.lewisdeane.ldialogs:ldialogs:1.2.0@aar'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,16 +20,16 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    compile project(':lib')
-    compile 'androidx.appcompat:appcompat:1.0.0'
+    implementation project(':lib')
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 
     //Lollipop dialogs https://github.com/lewisjdeane/L-Dialogs and buttons, animations etc...
-    compile 'uk.me.lewisdeane.ldialogs:ldialogs:1.2.0@aar'
+    implementation 'uk.me.lewisdeane.ldialogs:ldialogs:1.2.0@aar'
 
     //test
-    androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.5.2'
+    androidTestImplementation 'com.jayway.android.robotium:robotium-solo:5.5.2'
 }
 
 // REQUIRED: Google's new Maven repo is required for the latest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.github.orangegangsters.lollipin"
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -23,7 +23,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
 
     compile project(':lib')
-    compile 'com.android.support:appcompat-v7:26.0.2'
+    compile 'com.android.support:appcompat-v7:28.0.0'
 
     //Lollipop dialogs https://github.com/lewisjdeane/L-Dialogs and buttons, animations etc...
     compile 'uk.me.lewisdeane.ldialogs:ldialogs:1.2.0@aar'

--- a/app/src/main/java/com/github/omadahealth/lollipin/LockedCompatActivity.java
+++ b/app/src/main/java/com/github/omadahealth/lollipin/LockedCompatActivity.java
@@ -1,7 +1,7 @@
 package com.github.omadahealth.lollipin;
 
 import android.os.Bundle;
-import android.support.v7.widget.Toolbar;
+import androidx.appcompat.widget.Toolbar;
 import com.github.omadahealth.lollipin.lib.PinCompatActivity;
 import lollipin.orangegangsters.github.com.lollipin.R;
 

--- a/app/src/main/res/layout/activity_compat_locked.xml
+++ b/app/src/main/res/layout/activity_compat_locked.xml
@@ -3,7 +3,7 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.Toolbar
+    <androidx.appcompat.widget.Toolbar
         android:id="@+id/id_toolbar"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,6 +19,7 @@ allprojects {
             url "https://github.com/omadahealth/omada-nexus/raw/master/release"
         }
         jcenter()
+        google()
 
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,4 +36,6 @@ POM_DEVELOPER_NAME=Olivier Goutay & Stoyan Dimitrov & Dae Park
 POM_NAME=LolliPin Library
 POM_ARTIFACT_ID=lollipin
 POM_PACKAGING=aar
+android.useAndroidX=true
+android.enableJetifier=true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 17 11:56:01 PDT 2017
+#Tue Jan 07 16:51:10 EST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,9 +26,9 @@ dependencies {
     implementation 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
 
     //Compat
-    implementation 'com.android.support:support-v4:28.0.0'
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation "com.android.support:support-v13:28.0.0"
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.legacy:legacy-support-v13:1.0.0'
 }
 repositories {
     maven {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -19,16 +19,16 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     //RippleView
-    compile 'com.github.traex.rippleeffect:ripple:1.3.1-OG'
+    implementation 'com.github.traex.rippleeffect:ripple:1.3.1-OG'
     //TypefaceView
-    compile 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
+    implementation 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
 
     //Compat
-    compile 'com.android.support:support-v4:28.0.0'
-    compile 'com.android.support:appcompat-v7:28.0.0'
-    compile "com.android.support:support-v13:28.0.0"
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation "com.android.support:support-v13:28.0.0"
 }
 repositories {
     maven {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.1'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 2
         versionName VERSION_NAME
     }
@@ -26,9 +26,9 @@ dependencies {
     compile 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
 
     //Compat
-    compile 'com.android.support:support-v4:26.0.2'
-    compile 'com.android.support:appcompat-v7:26.0.2'
-    compile "com.android.support:support-v13:26.0.2"
+    compile 'com.android.support:support-v4:28.0.0'
+    compile 'com.android.support:appcompat-v7:28.0.0'
+    compile "com.android.support:support-v13:28.0.0"
 }
 repositories {
     maven {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'com.github.traex.rippleeffect:ripple:1.3.1-OG'
     //TypefaceView
     implementation 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
+    // Biometrics
+    implementation 'androidx.biometric:biometric:1.0.1'
 
     //Compat
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
@@ -7,7 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface;
 import com.github.omadahealth.lollipin.lib.managers.AppLockActivity;

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinActivity.java
@@ -1,12 +1,13 @@
 package com.github.omadahealth.lollipin.lib;
 
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface;
@@ -18,7 +19,7 @@ import com.github.omadahealth.lollipin.lib.managers.AppLockActivity;
  * Then to enable PinCode blocking, you must call
  * {@link com.github.omadahealth.lollipin.lib.managers.LockManager#enableAppLock(android.content.Context, Class)}
  */
-public class PinActivity extends Activity {
+public class PinActivity extends AppCompatActivity {
     private static LifeCycleInterface mLifeCycleListener;
     private final BroadcastReceiver mPinCancelledReceiver;
 
@@ -41,7 +42,7 @@ public class PinActivity extends Activity {
 
     @Override
     public void onUserInteraction() {
-        if (mLifeCycleListener != null){
+        if (mLifeCycleListener != null) {
             mLifeCycleListener.onActivityUserInteraction(PinActivity.this);
         }
         super.onUserInteraction();

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinCompatActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinCompatActivity.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.support.v4.content.LocalBroadcastManager;
-import android.support.v7.app.AppCompatActivity;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface;
 import com.github.omadahealth.lollipin.lib.managers.AppLockActivity;

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinFragmentActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/PinFragmentActivity.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.fragment.app.FragmentActivity;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface;
 import com.github.omadahealth.lollipin.lib.managers.AppLockActivity;

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLock.java
@@ -202,4 +202,15 @@ public abstract class AppLock {
      * Otherwise returns true
      */
     public abstract boolean shouldLockSceen(Activity activity);
+
+    /**
+     * On successful login, this resets the login attempt count to 0
+     */
+    public abstract void resetLoginAttempts();
+
+    /**
+     * Increments the number of login attempts made, and returns the new value
+     * @return value after incremented
+     */
+    public abstract int incrementAndGetLoginAttempts();
 }

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLock.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLock.java
@@ -147,14 +147,14 @@ public abstract class AppLock {
     /**
      * Get the last active time of the app used by {@link #shouldLockSceen(android.app.Activity)}
      */
-    public abstract long getLastActiveMillis();
+    public abstract long getLastActiveUptimeNanos();
 
     /**
      * Set the last active time of the app used by {@link #shouldLockSceen(android.app.Activity)}.
      * Set in {@link com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface#onActivityPaused(android.app.Activity)}
      * and {@link com.github.omadahealth.lollipin.lib.interfaces.LifeCycleInterface#onActivityResumed(android.app.Activity)}
      */
-    public abstract void setLastActiveMillis();
+    public abstract void updateLastActiveUptimeNanos();
 
     /**
      * Set the passcode (store his SHA1 into {@link android.content.SharedPreferences}) using the

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -5,7 +5,7 @@ import android.content.Intent;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v4.content.LocalBroadcastManager;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.util.Log;
 import android.view.View;
 import android.view.animation.Animation;

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -144,7 +144,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             mFingerprintManager = (FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE);
             mFingerprintUiHelper = new FingerprintUiHelper.FingerprintUiHelperBuilder(mFingerprintManager).build(mFingerprintImageView, mFingerprintTextView, this);
             try {
-            if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
+            if (mFingerprintManager != null && mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
                     && mLockManager.getAppLock().isFingerprintAuthEnabled()) {
                     mFingerprintImageView.setVisibility(View.VISIBLE);
                     mFingerprintTextView.setVisibility(View.VISIBLE);

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -273,7 +273,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
             if (mLockManager != null) {
                 AppLock appLock = mLockManager.getAppLock();
                 if (appLock != null) {
-                    appLock.setLastActiveMillis();
+                    appLock.updateLastActiveUptimeNanos();
                 }
             }
         }

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -229,21 +229,21 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      */
     public @NonNull
     String getBiometricPromptTitle() {
-        return getString(R.string.biometric_prompt_title);
+        return getString(R.string.pin_code_biometric_prompt_title);
     }
 
     /**
      * Override to change the biometric/fingerprint prompt subtitle.
      */
     public String getBiometricPromptSubtitle() {
-        return getString(R.string.biometric_prompt_subtitle);
+        return getString(R.string.pin_code_biometric_prompt_subtitle);
     }
 
     /**
      * Override to change the biometric/fingerprint prompt cancellation text.
      */
     public String getBiometricPromptCancelText() {
-        return getString(R.string.biometric_cancel_use_pin);
+        return getString(R.string.pin_code_biometric_cancel_use_pin);
     }
 
     /**

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -49,7 +49,6 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     protected FingerprintUiHelper mFingerprintUiHelper;
 
     protected int mType = AppLock.UNLOCK_PIN;
-    protected int mAttempts = 1;
     protected String mPinCode;
 
     protected String mOldPinCode;
@@ -388,7 +387,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
      * Run a shake animation when the password is not valid.
      */
     protected void onPinCodeError() {
-        onPinFailure(mAttempts++);
+        onPinFailure(mLockManager.getAppLock().incrementAndGetLoginAttempts());
         Thread thread = new Thread() {
             public void run() {
                 mPinCode = "";
@@ -403,8 +402,8 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
 
     protected void onPinCodeSuccess() {
         isCodeSuccessful = true;
-        onPinSuccess(mAttempts);
-        mAttempts = 1;
+        onPinSuccess(mLockManager.getAppLock().incrementAndGetLoginAttempts());
+        mLockManager.getAppLock().resetLoginAttempts();
     }
 
     /**

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
@@ -422,12 +422,8 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
             Intent intent = new Intent(activity.getApplicationContext(),
                     mActivityClass);
             intent.putExtra(AppLock.EXTRA_TYPE, AppLock.UNLOCK_PIN);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             activity.getApplication().startActivity(intent);
-        }
-
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
-            return;
         }
 
         if (!shouldLockSceen(activity) && !(activity instanceof AppLockActivity)) {

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
@@ -66,6 +66,10 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
      */
     private static final String FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY = "FINGERPRINT_AUTH_ENABLED_PREFERENCE_KEY";
     /**
+     * The {@link SharedPreferences} key used to store the number of login attempts the user has made
+     */
+    private static final String NUMBER_OF_PASSCODE_ATTEMPTS_PREFERENCE_KEY = "NUMBER_OF_PASSCODE_ATTEMPTS_PREFERENCE_KEY";
+    /**
      * The default password salt
      */
     private static final String DEFAULT_PASSWORD_SALT = "7xn7@c$";
@@ -319,6 +323,18 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
         }
 
         return false;
+    }
+
+    @Override
+    public void resetLoginAttempts() {
+        mSharedPreferences.edit().putInt(NUMBER_OF_PASSCODE_ATTEMPTS_PREFERENCE_KEY, 0).apply();
+    }
+
+    @Override
+    public int incrementAndGetLoginAttempts() {
+        int attempts = mSharedPreferences.getInt(NUMBER_OF_PASSCODE_ATTEMPTS_PREFERENCE_KEY, 0) + 1;
+        mSharedPreferences.edit().putInt(NUMBER_OF_PASSCODE_ATTEMPTS_PREFERENCE_KEY, attempts).apply();
+        return attempts;
     }
 
     @Override

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockImpl.java
@@ -419,11 +419,11 @@ public class AppLockImpl<T extends AppLockActivity> extends AppLock implements L
 
         if (shouldLockSceen(activity)) {
             Log.d(TAG, "mActivityClass.getClass() " + mActivityClass);
-            Intent intent = new Intent(activity.getApplicationContext(),
+            Intent intent = new Intent(activity,
                     mActivityClass);
             intent.putExtra(AppLock.EXTRA_TYPE, AppLock.UNLOCK_PIN);
             intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            activity.getApplication().startActivity(intent);
+            activity.startActivity(intent);
         }
 
         if (!shouldLockSceen(activity) && !(activity instanceof AppLockActivity)) {

--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/views/SquareImageView.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/views/SquareImageView.java
@@ -2,12 +2,11 @@ package com.github.omadahealth.lollipin.lib.views;
 
 import android.content.Context;
 import android.util.AttributeSet;
-import android.widget.ImageView;
 
 /**
  * An ImageView that shrinks its larger dimension to become square.
  */
-public class SquareImageView extends android.support.v7.widget.AppCompatImageView {
+public class SquareImageView extends androidx.appcompat.widget.AppCompatImageView {
     public SquareImageView(Context context) {
         super(context);
     }

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -30,5 +30,8 @@
     <string name="pin_code_fingerprint_text">Fingerprint</string>
     <string name="pin_code_fingerprint_success">Fingerprint recognized</string>
     <string name="pin_code_fingerprint_not_recognized">Fingerprint not recognized. Try again</string>
+    <string name="biometric_prompt_subtitle">Unlock using biometrics</string>
+    <string name="biometric_prompt_title">Unlock app</string>
+    <string name="biometric_cancel_use_pin">Use PIN</string>
 
 </resources>

--- a/lib/src/main/res/values/strings.xml
+++ b/lib/src/main/res/values/strings.xml
@@ -30,8 +30,8 @@
     <string name="pin_code_fingerprint_text">Fingerprint</string>
     <string name="pin_code_fingerprint_success">Fingerprint recognized</string>
     <string name="pin_code_fingerprint_not_recognized">Fingerprint not recognized. Try again</string>
-    <string name="biometric_prompt_subtitle">Unlock using biometrics</string>
-    <string name="biometric_prompt_title">Unlock app</string>
-    <string name="biometric_cancel_use_pin">Use PIN</string>
+    <string name="pin_code_biometric_prompt_subtitle">Unlock using biometrics</string>
+    <string name="pin_code_biometric_prompt_title">Unlock app</string>
+    <string name="pin_code_biometric_cancel_use_pin">Use PIN</string>
 
 </resources>


### PR DESCRIPTION
Close #178.

Currently, an attacker can bypass the limit on passcode attempts by trying N-1 passcodes, then killing the app. This PR saves the number of attempts to disk so that killing the app will not reset the number of passcode attempts.