### PR TITLE
Handle mFingerprintManager null exception

### DIFF
--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -140,10 +140,10 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     private void initLayoutForFingerprint() {
         mFingerprintImageView = (ImageView) this.findViewById(R.id.pin_code_fingerprint_imageview);
         mFingerprintTextView = (TextView) this.findViewById(R.id.pin_code_fingerprint_textview);
-        if (mType == AppLock.UNLOCK_PIN && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            mFingerprintManager = (FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE);
+        if (mType == AppLock.UNLOCK_PIN && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { 
             mFingerprintUiHelper = new FingerprintUiHelper.FingerprintUiHelperBuilder(mFingerprintManager).build(mFingerprintImageView, mFingerprintTextView, this);
             try {
+            mFingerprintManager = (FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE);
             if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
                     && mLockManager.getAppLock().isFingerprintAuthEnabled()) {
                     mFingerprintImageView.setVisibility(View.VISIBLE);


### PR DESCRIPTION
On some devices,
`(FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE)` 
may return a null pointer.
`Caused by: java.lang.NullPointerException: 
  at com.github.omadahealth.lollipin.lib.managers.AppLockActivity.initLayoutForFingerprint (AppLockActivity.java:147)
  at com.github.omadahealth.lollipin.lib.managers.AppLockActivity.onResume (AppLockActivity.java:84)`