### PR TITLE
Fixed NullPointerException

### DIFF
--- a/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
+++ b/lib/src/main/java/com/github/omadahealth/lollipin/lib/managers/AppLockActivity.java
@@ -140,12 +140,13 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
     private void initLayoutForFingerprint() {
         mFingerprintImageView = (ImageView) this.findViewById(R.id.pin_code_fingerprint_imageview);
         mFingerprintTextView = (TextView) this.findViewById(R.id.pin_code_fingerprint_textview);
-        if (mType == AppLock.UNLOCK_PIN && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        if (mType == AppLock.UNLOCK_PIN && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                && getSystemService(Context.FINGERPRINT_SERVICE) != null) {
             mFingerprintManager = (FingerprintManager) getSystemService(Context.FINGERPRINT_SERVICE);
             mFingerprintUiHelper = new FingerprintUiHelper.FingerprintUiHelperBuilder(mFingerprintManager).build(mFingerprintImageView, mFingerprintTextView, this);
             try {
-            if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
-                    && mLockManager.getAppLock().isFingerprintAuthEnabled()) {
+                if (mFingerprintManager.isHardwareDetected() && mFingerprintUiHelper.isFingerprintAuthAvailable()
+                        && mLockManager.getAppLock().isFingerprintAuthEnabled()) {
                     mFingerprintImageView.setVisibility(View.VISIBLE);
                     mFingerprintTextView.setVisibility(View.VISIBLE);
                     mFingerprintUiHelper.startListening();
@@ -218,7 +219,7 @@ public abstract class AppLockActivity extends PinActivity implements KeyboardBut
         return getString(R.string.pin_code_forgot_text);
     }
 
-    private void setForgotTextVisibility(){
+    private void setForgotTextVisibility() {
         mForgotTextView.setVisibility(mLockManager.getAppLock().shouldShowForgot(mType) ? View.VISIBLE : View.GONE);
     }
 


### PR DESCRIPTION
This exception occurred on devices without fingerprint function, such as: vivo Y71, vivo y93s
```
java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.hardware.fingerprint.FingerprintManager.isHardwareDetected()' on a null object reference
    at com.github.omadahealth.lollipin.lib.managers.AppLockActivity.initLayoutForFingerprint(AppLockActivity.java:147)
    at com.github.omadahealth.lollipin.lib.managers.AppLockActivity.onResume(AppLockActivity.java:84)
```