### PR TITLE
Fixing double end animation for RippleView

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     //RippleView
-    compile 'com.github.traex.rippleeffect:ripple:1.3.1-OG'
+    compile 'com.github.traex.rippleeffect:ripple:1.3.1-OG-2'
     //TypefaceView
     compile 'com.github.omadahealth.typefaceview:typefaceview:1.5.0@aar' //TypefaceTextView
 


### PR DESCRIPTION
relates to commit https://github.com/omadahealth/omada-nexus/commit/0f948bf3e32d405f9687f651e8db721f4da4b8d1